### PR TITLE
Change principal to use full arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "cross_account_role" {
   assume_role_policy = jsonencode({
     Statement = [
       {
-        Effect : "Allow", Principal : { AWS : var.infracost_account }, Action : ["sts:AssumeRole"],
+        Effect : "Allow", Principal : { AWS : "arn:aws:iam::${var.infracost_account}:root" }, Action : ["sts:AssumeRole"],
         Condition : { StringEquals : { "sts:ExternalId" : var.infracost_external_id } }
       }
     ]


### PR DESCRIPTION
To avoid TF constantly updating the `cross_account_role` the principal should use the full arn