### PR TITLE
fix: update iam role to avoid null changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,15 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      configuration_aliases = [ aws.us_east_1 ]
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.us_east_1]
     }
   }
 }
 
 resource "aws_iam_role" "cross_account_role" {
   assume_role_policy = jsonencode({
+    Version : "2012-10-17",
     Statement = [
       {
         Effect : "Allow", Principal : { AWS : "arn:aws:iam::${var.infracost_account}:root" }, Action : "sts:AssumeRole",
@@ -17,12 +18,13 @@ resource "aws_iam_role" "cross_account_role" {
     ]
   })
 
-  path                = "/"
+  path = "/"
 
   inline_policy {
     name   = "root"
     policy = jsonencode({
-      Version : "2012-10-17", Statement : [
+      Version : "2012-10-17",
+      Statement : [
         {
           Action : [
             "aws-portal:View*",
@@ -45,7 +47,8 @@ resource "aws_iam_role" "cross_account_role" {
   inline_policy {
     name   = "InfracostCloudWatchMetricsReadOnly"
     policy = jsonencode({
-      Version : "2012-10-17", Statement : [
+      Version : "2012-10-17",
+      Statement : [
         {
           Action : ["logs:List*", "logs:Describe*", "logs:StartQuery", "logs:StopQuery", "logs:Filter*", "logs:Get*"],
           Resource : "arn:aws:logs:*:*:log-group:/aws/containerinsights/*", Effect : "Allow",
@@ -65,7 +68,8 @@ resource "aws_iam_role" "cross_account_role" {
   inline_policy {
     name   = "InfracostAdditionalResourceReadOnly"
     policy = jsonencode({
-      Version : "2012-10-17", Statement : [
+      Version : "2012-10-17",
+      Statement : [
         {
           Effect : "Allow", Resource : "*", Action : [
           "a4b:List*",

--- a/main.tf
+++ b/main.tf
@@ -11,13 +11,12 @@ resource "aws_iam_role" "cross_account_role" {
   assume_role_policy = jsonencode({
     Statement = [
       {
-        Effect : "Allow", Principal : { AWS : "arn:aws:iam::${var.infracost_account}:root" }, Action : ["sts:AssumeRole"],
+        Effect : "Allow", Principal : { AWS : "arn:aws:iam::${var.infracost_account}:root" }, Action : "sts:AssumeRole",
         Condition : { StringEquals : { "sts:ExternalId" : var.infracost_external_id } }
       }
     ]
   })
 
-  managed_policy_arns = ["arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"]
   path                = "/"
 
   inline_policy {
@@ -322,6 +321,12 @@ resource "aws_iam_role" "cross_account_role" {
       ]
     })
   }
+}
+
+resource "aws_iam_policy_attachment" "cross_account_view_only" {
+  name       = "infracost-cross-account-view-only"
+  roles      = [aws_iam_role.cross_account_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }
 
 resource "aws_s3_bucket" "cost_and_usage_report_bucket" {


### PR DESCRIPTION
These changes fix Terraform reporting changes in unchanged use of the module:


```
!   resource "aws_iam_role" "cross_account_role" {
!       assume_role_policy    = jsonencode(
!           {
!               Statement = [
!                   {
!                       Action    = "sts:AssumeRole" -> [
+                           "sts:AssumeRole",
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
-               Version   = "2008-10-17" -> null
            }
        )
        id                    = "terraform-yyyyyyyyyy"
!       managed_policy_arns   = [
-           "arn:aws:iam::xxxxxxxxxxx:policy/ObjectGetCostandUsageReports",
            # (1 unchanged element hidden)
        ]
        name                  = "terraform-yyyyyyyyyy"
        tags                  = {}
        # (8 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }
```