### PR TITLE
feat: Repurpose cross account role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Infracost AWS Cross Account Linking module 
+# Infracost AWS Read Only Role
 
-A Terraform module to set up an AWS cross-account link for Infracost Cloud. This is required to enable [Actual Costs](https://www.infracost.io/docs/infracost_cloud/actual_costs/) in Infracost Cloud.
+A Terraform module to set up an AWS cross-account link for Infracost Cloud; this is required to enable in PR recommendations for in cloud optimizations.
+
+## Scope
+
+It is important to ensure that you have reviewed the permissions that this module will create in your AWS account. This module will create an IAM role in your AWS account that will allow Infracost to read compute optimization, trusted advisor and your AWS Cost Explorer data.
+
+This role will also have read-only access to services within your AWS account and a subset of CloudWatch metrics.
 
 ## How to use
 
@@ -8,34 +14,20 @@ Import the module into your codebase and provide the `infracost_external_id` var
 
 ```terraform
 provider "aws" {
-  # NOTE: this module can currently be deployed in us-east-1 or eu-central-1, these are the regions that your
-  #       S3 bucket for the AWS CUR and our SNS topic notification can be deployed in currently.
-  #       Email hello@infracost.io if you need another region as we need to deploy our SNS topic there first.
-  region  = "eu-central-1"
-}
-
-# Do not change this, this is the only region that the AWS CUR API supports, this should not matter for
-# you as your bucket can live in another region (described above).
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 module "infracost" {
-  source = "github.com/infracost/cross-account-link"
+  source                = "github.com/infracost/cross-account-link"
   infracost_external_id = "INFRACOST_ORGANIZATION_ID"
-  # add a provider for region `us-east-1` and pass this in using aws.us_east_1 alias.
+
   providers = {
-    aws.us_east_1 = aws.us_east_1
+    aws = aws
   }
 }
 
 output "infracost_cross_account_role_arn" {
   value = module.infracost.role_arn
-}
-
-output "infracost_cur_bucket_arn" {
-  value = module.infracost.bucket_arn
 }
 ```
 
@@ -43,7 +35,7 @@ Once you've run this module in your infrastructure you'll need to email Infracos
 
 ```text
 To: hello@infracost.io
-Subject: Enable AWS actual costs
+Subject: Enable AWS read-only access for Infracost Cloud
 
 Body:
 Hi, my name is Rafa and I'm the DevOps Lead at ACME Corporation.
@@ -51,7 +43,6 @@ Please enable the AWS actual costs feature for our organization:
 
 - Infracost Cloud org ID: $YOUR_INFRACOST_ORGANIZATION_ID
 - Our AWS Cross Account ARN: <terraform output infracost_cross_account_role_arn>
-- Our AWS CUR S3 Bucket ARN: <terraform output infracost_cur_bucket_arn>
 
 Regards,
 Rafa

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,9 +2,3 @@ output "role_arn" {
   description = "The ARN value of the Cross-Account Role with IAM read-only permissions. Provide this to Infracost."
   value       = aws_iam_role.cross_account_role.arn
 }
-
-
-output "bucket_arn" {
-  description = "The ARN value of the bucket where the CUR will be stored. Provide this to Infracost."
-  value       = aws_s3_bucket.cost_and_usage_report_bucket.arn
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,22 @@
 variable "infracost_external_id" {
-  description = "Your Infracost Organization ID (get it from Org Settings in https://dashboard.infracost.io)"
+  description = "Your Infracost Organization ID (get it from Org Settings under Settings in the https://dashboard.infracost.io)"
   type        = string
 }
-
 
 variable "infracost_account" {
   description = "The Infracost account ID which has permission to your account."
   type        = string
   default     = "237144093413"
+}
+
+variable "include_cloudwatch_readonly_policy" {
+  description = "Whether to include the CloudWatch read-only policy in the Cross-Account Role."
+  type        = bool
+  default     = true
+}
+
+variable "include_services_readonly_policy" {
+  description = "Whether to include the services read-only policy in the Cross-Account Role."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
- add the permissions for compute-optimizer, cost-optimization-hub and trusted advisor
- leave the existing permissions intact
- break out the policies into specific resource, inline policies are deprecated in the terraform
- remove the s3 curs bucket - this isn't needed any more
- update the README instructions

### Test Run in Dev

![image](https://github.com/user-attachments/assets/546c6575-5a07-4860-9d02-1de89a5265e2)

IC-1988

