### PR TITLE
feat: add readonly policy for storage lens exports

### DIFF
--- a/storagelens.tf
+++ b/storagelens.tf
@@ -1,0 +1,35 @@
+resource "aws_iam_policy" "storage_lens_s3_readonly_policy" {
+  count       = var.is_management_account && length(var.storage_lens_bucket_arns) > 0 ? 1 : 0
+  name        = "infracost-storage-lens-s3-readonly${var.role_suffix}"
+  path        = "/"
+  description = "Infracost Storage Lens S3 read-only policy"
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Sid : "InfracostStorageLensS3BucketAccess"
+        Effect : "Allow"
+        Action : [
+          "s3:ListBucket",
+        ]
+        Resource : var.storage_lens_bucket_arns
+      },
+      {
+        Sid : "InfracostStorageLensS3ObjectAccess"
+        Effect : "Allow"
+        Action : [
+          "s3:GetObject",
+          "s3:HeadObject",
+        ]
+        Resource : [for arn in var.storage_lens_bucket_arns : "${arn}/*"]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "storage_lens_s3_readonly_policy_attachment" {
+  count      = var.is_management_account && length(var.storage_lens_bucket_arns) > 0 ? 1 : 0
+  policy_arn = aws_iam_policy.storage_lens_s3_readonly_policy[count.index].arn
+  role       = aws_iam_role.cross_account_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,9 @@ variable "role_suffix" {
   type        = string
   default     = ""
 }
+
+variable "storage_lens_bucket_arns" {
+  description = "List of S3 bucket ARNs to grant read access to for Storage Lens data. Only applies to the management account."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Adds a policy attachment to the cross account role that grants S3 read permissions on whitelisted bucket ARNs for Storage Lens data.

Usage example:
```terraform
module "cross_account_link" {
  source = "github.com/infracost/cross-account-link?ref=v0.6.0"
  infracost_external_id = "INFRACOST_ORGANIZATION_ID"
  is_management_account = true
  providers = {
    aws = aws
  }

  storage_lens_bucket_arns = [
    "arn:aws:s3:::my-storage-lens-exports-bucket",
    "arn:aws:s3:::my-other-storage-lens-exports-bucket"
  ]
}

```