### PR TITLE
feat: add data export modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ A Terraform module to set up an AWS cross-account link for Infracost Cloud. This
     }
 
     module "infracost_management_account" {
-      source                     = "github.com/infracost/cross-account-link?ref=v0.7.0"
+      source                     = "github.com/infracost/cross-account-link?ref=v0.8.0"
       infracost_external_id      = "INFRACOST_ORGANIZATION_ID"
       is_management_account      = true
       providers = {
         aws = aws.management_account
       }
-      // Optional: add S3 bucket ARNs for CUR, FOCUS, or S3 Storage Lens data exports access
+      // Optional: add S3 bucket ARNs to expose additional data to Infracost.
       s3_bucket_arns = [
-        "arn:aws:s3:::infracost-exports-<AWS_ACCOUNT_ID>"
+        "arn:aws:s3:::my-custom-export"
       ]
     }
 
@@ -43,7 +43,7 @@ A Terraform module to set up an AWS cross-account link for Infracost Cloud. This
     }
 
     module "infracost_member_account_1" {
-      source                     = "github.com/infracost/cross-account-link?ref=v0.7.0"
+      source                     = "github.com/infracost/cross-account-link?ref=v0.8.0"
       infracost_external_id      = "INFRACOST_ORGANIZATION_ID"
       is_management_account      = false
       providers = {
@@ -82,3 +82,37 @@ A Terraform module to set up an AWS cross-account link for Infracost Cloud. This
 ## Updates
 
 When new FinOps policies or features are added, this module may need to be updated to include the new permissions. We will notify you when this is the case so you can update the version of the module.
+
+## Data exports
+
+Data exports help Infracost source real billing and usage data from your AWS account to enable improved accuracy.
+
+### Prerequisites
+
+- Modules must set `is_management_account = true`.
+- It is required that [S3 Storage Lens trusted access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_with_organizations_enabling_trusted_access.html) is enabled in your AWS Organization for Storage Lens exports.
+
+### Usage
+
+Setting `enable_data_exports = true` provisions the following:
+- A daily Billing and Cost Management (BCM) FOCUS 1.2 export for visibility into resource costs and usage, with a dedicated S3 bucket.
+- An S3 Storage Lens configuration for organization-wide visibility into bucket usage, with a dedicated S3 bucket.
+- Read-only access to both buckets for the Infracost cross-account role.
+
+```terraform
+module "infracost_management_account" {
+  source                = "github.com/infracost/cross-account-link?ref=v0.8.0"
+  infracost_external_id = "INFRACOST_ORGANIZATION_ID"
+  is_management_account = true
+  enable_data_exports   = true
+  providers = {
+    aws = aws.management_account
+  }
+}
+```
+
+### Data ownership and lifecycle
+
+Data remains under the ownership of the customer AWS account. Infracost is permitted solely read-only access.
+
+Each data exports bucket is configured with a 365-day lifecycle before objects are deleted. Intelligent tiering is used to reduce storage costs.

--- a/exports.tf
+++ b/exports.tf
@@ -1,0 +1,30 @@
+resource "terraform_data" "validate_is_management" {
+  count = var.enable_data_exports ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = var.is_management_account
+      error_message = "enable_data_exports can only be true when is_management_account is true."
+    }
+  }
+}
+
+module "billing_and_cost_management_export" {
+  count  = var.enable_data_exports ? 1 : 0
+  source = "./modules/billing-and-cost-management"
+
+  depends_on = [terraform_data.validate_is_management]
+
+  aws_account_id = data.aws_caller_identity.current.account_id
+}
+
+module "s3_storage_lens_export" {
+  count  = var.enable_data_exports ? 1 : 0
+  source = "./modules/s3-storage-lens"
+
+  depends_on = [terraform_data.validate_is_management]
+
+  aws_account_id         = data.aws_caller_identity.current.account_id
+  aws_organization_arn   = data.aws_organizations_organization.current.arn
+  aws_trusted_principals = data.aws_organizations_organization.current.aws_service_access_principals
+}

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,9 @@ terraform {
   }
 }
 
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+data "aws_organizations_organization" "current" {}
 
 resource "aws_iam_role" "cross_account_role" {
   name = "infracost-readonly${var.role_suffix}"

--- a/modules/billing-and-cost-management/bucket.tf
+++ b/modules/billing-and-cost-management/bucket.tf
@@ -1,0 +1,59 @@
+resource "aws_s3_bucket" "bcm_data_exports" {
+  bucket = "infracost-bcm-exports-${var.aws_account_id}"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {
+  bucket = aws_s3_bucket.bcm_data_exports.id
+
+  rule {
+    id     = "intelligent-tiering"
+    status = "Enabled"
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+data "aws_iam_policy_document" "data_exports_policy_doc" {
+  statement {
+    sid    = "AllowBCMDataExportsWrite"
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "bcm-data-exports.amazonaws.com",
+        "billingreports.amazonaws.com",
+      ]
+    }
+
+    actions = [
+      "s3:GetBucketPolicy",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.bcm_data_exports.arn,
+      "${aws_s3_bucket.bcm_data_exports.arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [
+        var.aws_account_id,
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "data_exports_policy" {
+  bucket = aws_s3_bucket.bcm_data_exports.id
+  policy = data.aws_iam_policy_document.data_exports_policy_doc.json
+}

--- a/modules/billing-and-cost-management/main.tf
+++ b/modules/billing-and-cost-management/main.tf
@@ -1,0 +1,99 @@
+locals {
+  # https://focus.finops.org/focus-specification/v1-2/
+  focus_1_2_columns = [
+    "AvailabilityZone",
+    "BilledCost",
+    "BillingAccountId",
+    "BillingAccountName",
+    "BillingAccountType",
+    "BillingCurrency",
+    "BillingPeriodEnd",
+    "BillingPeriodStart",
+    "CapacityReservationId",
+    "CapacityReservationStatus",
+    "ChargeCategory",
+    "ChargeClass",
+    "ChargeDescription",
+    "ChargeFrequency",
+    "ChargePeriodEnd",
+    "ChargePeriodStart",
+    "CommitmentDiscountCategory",
+    "CommitmentDiscountId",
+    "CommitmentDiscountName",
+    "CommitmentDiscountQuantity",
+    "CommitmentDiscountType",
+    "CommitmentDiscountStatus",
+    "CommitmentDiscountUnit",
+    "ConsumedQuantity",
+    "ConsumedUnit",
+    "ContractedCost",
+    "ContractedUnitPrice",
+    "EffectiveCost",
+    "InvoiceId",
+    "InvoiceIssuerName",
+    "ListCost",
+    "ListUnitPrice",
+    "PricingCategory",
+    "PricingCurrency",
+    "PricingCurrencyContractedUnitPrice",
+    "PricingCurrencyEffectiveCost",
+    "PricingCurrencyListUnitPrice",
+    "PricingQuantity",
+    "PricingUnit",
+    "ProviderName",
+    "PublisherName",
+    "RegionId",
+    "RegionName",
+    "ResourceId",
+    "ResourceName",
+    "ResourceType",
+    "ServiceCategory",
+    "ServiceName",
+    "ServiceSubcategory",
+    "SkuId",
+    "SkuPriceDetails",
+    "SkuPriceId",
+    "SkuMeter",
+    "SubAccountId",
+    "SubAccountName",
+    "SubAccountType",
+    "Tags",
+    "x_Discounts",
+    "x_Operation",
+    "x_ServiceCode",
+  ]
+}
+
+resource "aws_bcmdataexports_export" "daily_focus" {
+  export {
+    name = "InfracostDailyFocusExport"
+
+    data_query {
+      query_statement = format("SELECT %s FROM FOCUS_1_2_AWS", join(", ", local.focus_1_2_columns))
+      table_configurations = {
+        "FOCUS_1_2_AWS" = {
+          "TIME_GRANULARITY" = "DAILY"
+        }
+      }
+    }
+
+    destination_configurations {
+      s3_destination {
+        s3_region = aws_s3_bucket.bcm_data_exports.region
+        s3_bucket = aws_s3_bucket.bcm_data_exports.id
+        s3_prefix = ""
+
+        s3_output_configurations {
+          overwrite   = "OVERWRITE_REPORT"
+          format      = "PARQUET"
+          compression = "PARQUET"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}

--- a/modules/billing-and-cost-management/outputs.tf
+++ b/modules/billing-and-cost-management/outputs.tf
@@ -1,0 +1,9 @@
+output "export_arn" {
+  description = "The ARN of the BCM Data Exports export."
+  value       = aws_bcmdataexports_export.daily_focus.export[0].export_arn
+}
+
+output "bucket_arn" {
+  description = "The ARN of the BCM data exports S3 bucket."
+  value       = aws_s3_bucket.bcm_data_exports.arn
+}

--- a/modules/billing-and-cost-management/variables.tf
+++ b/modules/billing-and-cost-management/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_account_id" {
+  description = "The AWS account ID."
+  type        = string
+}

--- a/modules/s3-storage-lens/bucket.tf
+++ b/modules/s3-storage-lens/bucket.tf
@@ -1,0 +1,58 @@
+resource "aws_s3_bucket" "storage_lens_data_exports" {
+  bucket = "infracost-storagelens-exports-${var.aws_account_id}"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {
+  bucket = aws_s3_bucket.storage_lens_data_exports.id
+
+  rule {
+    id     = "intelligent-tiering"
+    status = "Enabled"
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+data "aws_iam_policy_document" "data_exports_policy_doc" {
+  statement {
+    sid    = "AllowStorageLensDataExportsWrite"
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "storage-lens.s3.amazonaws.com",
+      ]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+
+    resources = [
+      aws_s3_bucket.storage_lens_data_exports.arn,
+      "${aws_s3_bucket.storage_lens_data_exports.arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [
+        var.aws_account_id,
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "data_exports_policy" {
+  bucket = aws_s3_bucket.storage_lens_data_exports.id
+  policy = data.aws_iam_policy_document.data_exports_policy_doc.json
+}

--- a/modules/s3-storage-lens/main.tf
+++ b/modules/s3-storage-lens/main.tf
@@ -1,0 +1,63 @@
+# Requires trusted access to be configured for cross account visibility.
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_with_organizations_enabling_trusted_access.html
+resource "terraform_data" "validate_trusted_access" {
+  lifecycle {
+    precondition {
+      condition     = contains(var.aws_trusted_principals, "storage-lens.s3.amazonaws.com")
+      error_message = "S3 Storage Lens must have trusted access configured for cross-account visibility: https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_with_organizations_enabling_trusted_access.html"
+    }
+  }
+}
+
+resource "aws_s3control_storage_lens_configuration" "export" {
+  depends_on = [terraform_data.validate_trusted_access]
+  config_id  = "InfracostStorageLensExport"
+
+  storage_lens_configuration {
+    enabled = true
+
+    account_level {
+      activity_metrics {
+        enabled = true
+      }
+
+      advanced_cost_optimization_metrics {
+        enabled = true
+      }
+
+      # https://github.com/hashicorp/terraform-provider-aws/issues/46851
+      # advanced_performance_metrics {
+      #   enabled = true
+      # }
+
+      bucket_level {
+        activity_metrics {
+          enabled = true
+        }
+
+        advanced_cost_optimization_metrics {
+          enabled = true
+        }
+
+        # https://github.com/hashicorp/terraform-provider-aws/issues/46851
+        # advanced_performance_metrics {
+        #   enabled = true
+        # }
+      }
+    }
+
+    aws_org {
+      arn = var.aws_organization_arn
+    }
+
+    data_export {
+      s3_bucket_destination {
+        account_id            = var.aws_account_id
+        arn                   = aws_s3_bucket.storage_lens_data_exports.arn
+        prefix                = ""
+        format                = "Parquet"
+        output_schema_version = "V_1"
+      }
+    }
+  }
+}

--- a/modules/s3-storage-lens/outputs.tf
+++ b/modules/s3-storage-lens/outputs.tf
@@ -1,0 +1,9 @@
+output "configuration_arn" {
+  description = "The ARN of the S3 Storage Lens configuration."
+  value       = aws_s3control_storage_lens_configuration.export.arn
+}
+
+output "bucket_arn" {
+  description = "The ARN of the Storage Lens data exports S3 bucket."
+  value       = aws_s3_bucket.storage_lens_data_exports.arn
+}

--- a/modules/s3-storage-lens/variables.tf
+++ b/modules/s3-storage-lens/variables.tf
@@ -1,0 +1,14 @@
+variable "aws_organization_arn" {
+  description = "The ARN of the AWS Organization for Storage Lens configuration scope."
+  type        = string
+}
+
+variable "aws_trusted_principals" {
+  description = "The list of trusted principals for organization wide visibility."
+  type        = list(string)
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID for the Storage Lens configuration."
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,34 @@
+output "account_id" {
+  description = "The AWS account ID where the module was provisioned."
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "account_region" {
+  description = "The AWS region of the account where the module was provisioned."
+  value       = data.aws_region.current.name
+}
+
 output "role_arn" {
   description = "The ARN value of the Cross-Account Role with IAM read-only permissions. Provide this to Infracost."
   value       = aws_iam_role.cross_account_role.arn
+}
+
+output "billing_and_cost_management_export_arn" {
+  description = "The ARN of the BCM Data Exports export. Provide this to Infracost."
+  value       = var.enable_data_exports ? module.billing_and_cost_management_export[0].export_arn : null
+}
+
+output "billing_and_cost_management_bucket_arn" {
+  description = "The ARN of the S3 bucket used for BCM Data Exports. Provide this to Infracost."
+  value       = var.enable_data_exports ? module.billing_and_cost_management_export[0].bucket_arn : null
+}
+
+output "s3_storage_lens_configuration_arn" {
+  description = "The ARN of the S3 Storage Lens configuration. Provide this to Infracost."
+  value       = var.enable_data_exports ? module.s3_storage_lens_export[0].configuration_arn : null
+}
+
+output "s3_storage_lens_bucket_arn" {
+  description = "The ARN of the S3 bucket used for S3 Storage Lens exports. Provide this to Infracost."
+  value       = var.enable_data_exports ? module.s3_storage_lens_export[0].bucket_arn : null
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,17 @@
+locals {
+  all_s3_bucket_arns = concat(
+    var.s3_bucket_arns,
+    var.enable_data_exports
+    ? [
+      module.billing_and_cost_management_export[0].bucket_arn,
+      module.s3_storage_lens_export[0].bucket_arn
+    ]
+    : []
+  )
+}
+
 resource "aws_iam_policy" "s3_access_policy" {
-  count       = length(var.s3_bucket_arns) > 0 ? 1 : 0
+  count       = length(local.all_s3_bucket_arns) > 0 ? 1 : 0
   name        = "infracost-s3-access${var.role_suffix}"
   path        = "/"
   description = "Infracost S3 read-only policy"
@@ -14,7 +26,7 @@ resource "aws_iam_policy" "s3_access_policy" {
           "s3:GetBucketLocation",
           "s3:ListBucket",
         ]
-        Resource : var.s3_bucket_arns
+        Resource : local.all_s3_bucket_arns
       },
       {
         Sid : "InfracostS3ObjectAccess"
@@ -23,14 +35,14 @@ resource "aws_iam_policy" "s3_access_policy" {
           "s3:GetObject",
           "s3:HeadObject",
         ]
-        Resource : [for arn in var.s3_bucket_arns : "${arn}/*"]
+        Resource : [for arn in local.all_s3_bucket_arns : "${arn}/*"]
       }
     ]
   })
 }
 
 resource "aws_iam_role_policy_attachment" "s3_access_policy_attachment" {
-  count      = length(var.s3_bucket_arns) > 0 ? 1 : 0
+  count      = length(local.all_s3_bucket_arns) > 0 ? 1 : 0
   policy_arn = aws_iam_policy.s3_access_policy[count.index].arn
   role       = aws_iam_role.cross_account_role.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,9 @@ variable "s3_bucket_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_data_exports" {
+  description = "Whether to enable billing and usage data exports provisioning."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds opt-in data exports for FOCUS reports and Storage Lens exports. These are implemented as submodules that get deployed alongside the cross account role to ensure that the role has scoped access to the bucket ARNs.

- Both data sources get their respective buckets due to different permission concerns (BCM needs top level bucket access for managed programmatic tests).

Example buckets:
- `infracost-bcm-exports-988896524719`
- `infracost-storagelens-exports-988896524719`