### PR TITLE
feat: add Cost Optimization Hub data export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Terraform module to set up an AWS cross-account link for Infracost Cloud. This
     }
 
     module "infracost_management_account" {
-      source                     = "github.com/infracost/cross-account-link?ref=v0.8.0"
+      source                     = "github.com/infracost/cross-account-link?ref=v0.9.0"
       infracost_external_id      = "INFRACOST_ORGANIZATION_ID"
       is_management_account      = true
       providers = {
@@ -43,7 +43,7 @@ A Terraform module to set up an AWS cross-account link for Infracost Cloud. This
     }
 
     module "infracost_member_account_1" {
-      source                     = "github.com/infracost/cross-account-link?ref=v0.8.0"
+      source                     = "github.com/infracost/cross-account-link?ref=v0.9.0"
       infracost_external_id      = "INFRACOST_ORGANIZATION_ID"
       is_management_account      = false
       providers = {
@@ -95,13 +95,15 @@ Data exports help Infracost source real billing and usage data from your AWS acc
 ### Usage
 
 Setting `enable_data_exports = true` provisions the following:
-- A daily Billing and Cost Management (BCM) FOCUS 1.2 export for visibility into resource costs and usage, with a dedicated S3 bucket.
-- An S3 Storage Lens configuration for organization-wide visibility into bucket usage, with a dedicated S3 bucket.
+- A daily BCM FOCUS 1.2 billing and cost export.
+- A daily BCM Cost Optimization Hub export with idle resource and savings recommendations.
+- An S3 Storage Lens configuration for organization-wide bucket usage metrics.
+- Dedicated S3 buckets for the above exports.
 - Read-only access to both buckets for the Infracost cross-account role.
 
 ```terraform
 module "infracost_management_account" {
-  source                = "github.com/infracost/cross-account-link?ref=v0.8.0"
+  source                = "github.com/infracost/cross-account-link?ref=v0.9.0"
   infracost_external_id = "INFRACOST_ORGANIZATION_ID"
   is_management_account = true
   enable_data_exports   = true

--- a/modules/billing-and-cost-management/main.tf
+++ b/modules/billing-and-cost-management/main.tf
@@ -64,6 +64,78 @@ locals {
   ]
 }
 
+locals {
+  # https://docs.aws.amazon.com/cur/latest/userguide/dataexports-create-standard.html
+  cost_optimization_columns = [
+    "account_id",
+    "account_name",
+    "recommendation_id",
+    "resource_arn",
+    "region",
+    "current_resource_type",
+    "recommended_resource_type",
+    "action_type",
+    "current_resource_summary",
+    "recommended_resource_summary",
+    "estimated_monthly_cost_before_discount",
+    "estimated_monthly_cost_after_discount",
+    "estimated_monthly_savings_before_discount",
+    "estimated_monthly_savings_after_discount",
+    "estimated_savings_percentage_before_discount",
+    "estimated_savings_percentage_after_discount",
+    "currency_code",
+    "restart_needed",
+    "rollback_possible",
+    "implementation_effort",
+    "tags",
+    "current_resource_details",
+    "recommended_resource_details",
+    "recommendation_source",
+    "recommendation_lookback_period_in_days",
+    "last_refresh_timestamp",
+  ]
+}
+
+resource "aws_iam_service_linked_role" "bcm_data_exports" {
+  aws_service_name = "bcm-data-exports.amazonaws.com"
+}
+
+resource "aws_bcmdataexports_export" "daily_cost_optimization" {
+  depends_on = [aws_iam_service_linked_role.bcm_data_exports]
+
+  export {
+    name = "InfracostDailyCostOptimizationExport"
+
+    data_query {
+      query_statement = format("SELECT %s FROM COST_OPTIMIZATION_RECOMMENDATIONS", join(", ", local.cost_optimization_columns))
+      table_configurations = {
+        "COST_OPTIMIZATION_RECOMMENDATIONS" = {
+          "INCLUDE_ALL_RECOMMENDATIONS" = "TRUE"
+        }
+      }
+    }
+
+    destination_configurations {
+      s3_destination {
+        s3_region = aws_s3_bucket.bcm_data_exports.region
+        s3_bucket = aws_s3_bucket.bcm_data_exports.id
+        s3_prefix = ""
+
+        s3_output_configurations {
+          overwrite   = "OVERWRITE_REPORT"
+          format      = "PARQUET"
+          compression = "PARQUET"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}
+
 resource "aws_bcmdataexports_export" "daily_focus" {
   export {
     name = "InfracostDailyFocusExport"


### PR DESCRIPTION
Add `InfracostDailyCostOptimizationExport` to the billing-and-cost-management submodule, alongside the existing FOCUS export. This exports all Cost Optimization Hub recommendations (idle resources, rightsizing, RI/SP purchase suggestions) as daily Parquet to the same BCM exports bucket.

Also creates the `AWSServiceRoleForBCMDataExports` service-linked role, which is required by the `COST_OPTIMIZATION_RECOMMENDATIONS` table but not by FOCUS.

## Deployment

1. Merge and tag a new release (e.g. `v0.9.0`)
2. Bump the module ref in `infracost/infra` `mgmt/main.tf`:
   ```hcl
   module "infracost_management_account" {
     source = "github.com/infracost/cross-account-link?ref=v0.9.0"
     ...
   }
   ```
3. Apply targeted from the `mgmt` directory:
   ```bash
   terraform plan \
     -target='module.infracost_management_account.module.billing_and_cost_management_export[0].aws_iam_service_linked_role.bcm_data_exports' \
     -target='module.infracost_management_account.module.billing_and_cost_management_export[0].aws_bcmdataexports_export.daily_cost_optimization' \
     -out=coh-export.tfplan
   terraform apply coh-export.tfplan
   ```

## Checklist

- [x] [Technical docs](https://github.com/infracost/technical-docs) updated (or not needed)