### PR TITLE
fix: add default FILTER to Cost Optimization Hub table config

### DIFF
--- a/modules/billing-and-cost-management/main.tf
+++ b/modules/billing-and-cost-management/main.tf
@@ -111,6 +111,7 @@ resource "aws_bcmdataexports_export" "daily_cost_optimization" {
       table_configurations = {
         "COST_OPTIMIZATION_RECOMMENDATIONS" = {
           "INCLUDE_ALL_RECOMMENDATIONS" = "TRUE"
+          "FILTER"                      = "{}"
         }
       }
     }


### PR DESCRIPTION
AWS adds a default `FILTER="{}"` to the table configuration. Without it the provider detects drift and forces replacement on every plan.

## Checklist

- [x] [Technical docs](https://github.com/infracost/technical-docs) updated (or not needed)