### PR TITLE
feat: add module version and role permission introspection

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Checklist
+
+- [ ] Ensure you have bumped the `local.module_version` value in `main.tf` accordingly with semver conventions
+
+## Release procedure
+
+After this PR is merged, cut a release with:
+
+```
+gh release create vX.Y.Z --generate-notes
+```

--- a/exports.tf
+++ b/exports.tf
@@ -16,6 +16,7 @@ module "billing_and_cost_management_export" {
   depends_on = [terraform_data.validate_is_management]
 
   aws_account_id = data.aws_caller_identity.current.account_id
+  tags           = local.common_tags
 }
 
 module "s3_storage_lens_export" {
@@ -27,4 +28,5 @@ module "s3_storage_lens_export" {
   aws_account_id         = data.aws_caller_identity.current.account_id
   aws_organization_arn   = data.aws_organizations_organization.current.arn
   aws_trusted_principals = data.aws_organizations_organization.current.aws_service_access_principals
+  tags                   = local.common_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,17 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 data "aws_organizations_organization" "current" {}
 
+locals {
+  // Bump on each release. Surfaced as the InfracostModuleVersion tag on every
+  // resource this module creates, so Infracost can detect which module
+  // version provisioned the role.
+  module_version = "v0.11.0"
+
+  common_tags = {
+    InfracostModuleVersion = local.module_version
+  }
+}
+
 resource "aws_iam_role" "cross_account_role" {
   name = "infracost-readonly${var.role_suffix}"
   assume_role_policy = jsonencode({
@@ -22,6 +33,8 @@ resource "aws_iam_role" "cross_account_role" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
 locals {
@@ -149,6 +162,8 @@ resource "aws_iam_policy" "management_account_readonly_policy" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "management_account_readonly_policy_attachment" {
@@ -174,11 +189,53 @@ resource "aws_iam_policy" "member_account_readonly_policy" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
 # Attach policies to the role
 resource "aws_iam_role_policy_attachment" "member_account_readonly_policy_attachment" {
   count      = var.is_management_account ? 0 : 1
   policy_arn = aws_iam_policy.member_account_readonly_policy[count.index].arn
+  role       = aws_iam_role.cross_account_role.name
+}
+
+resource "aws_iam_policy" "role_introspection_policy" {
+  name        = "infracost-role-introspection${var.role_suffix}"
+  path        = "/"
+  description = "Allows the Infracost cross-account role to read and simulate its own permissions for feature detection"
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Sid : "InspectRole",
+        Effect : "Allow",
+        Action : [
+          "iam:GetRole",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:SimulatePrincipalPolicy",
+        ],
+        Resource : aws_iam_role.cross_account_role.arn,
+      },
+      {
+        Sid : "InspectAttachedPolicies",
+        Effect : "Allow",
+        Action : [
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+        ],
+        Resource : "*",
+      },
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "role_introspection_policy_attachment" {
+  policy_arn = aws_iam_policy.role_introspection_policy.arn
   role       = aws_iam_role.cross_account_role.name
 }

--- a/modules/billing-and-cost-management/bucket.tf
+++ b/modules/billing-and-cost-management/bucket.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "bcm_data_exports" {
   bucket = "infracost-bcm-exports-${var.aws_account_id}"
+  tags   = var.tags
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {

--- a/modules/billing-and-cost-management/main.tf
+++ b/modules/billing-and-cost-management/main.tf
@@ -135,6 +135,8 @@ resource "aws_bcmdataexports_export" "daily_cost_optimization" {
       frequency = "SYNCHRONOUS"
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_bcmdataexports_export" "daily_focus" {
@@ -169,4 +171,6 @@ resource "aws_bcmdataexports_export" "daily_focus" {
       frequency = "SYNCHRONOUS"
     }
   }
+
+  tags = var.tags
 }

--- a/modules/billing-and-cost-management/variables.tf
+++ b/modules/billing-and-cost-management/variables.tf
@@ -2,3 +2,9 @@ variable "aws_account_id" {
   description = "The AWS account ID."
   type        = string
 }
+
+variable "tags" {
+  description = "Tags applied to all resources created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/s3-storage-lens/bucket.tf
+++ b/modules/s3-storage-lens/bucket.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "storage_lens_data_exports" {
   bucket = "infracost-storagelens-exports-${var.aws_account_id}"
+  tags   = var.tags
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {

--- a/modules/s3-storage-lens/main.tf
+++ b/modules/s3-storage-lens/main.tf
@@ -60,4 +60,6 @@ resource "aws_s3control_storage_lens_configuration" "export" {
       }
     }
   }
+
+  tags = var.tags
 }

--- a/modules/s3-storage-lens/variables.tf
+++ b/modules/s3-storage-lens/variables.tf
@@ -12,3 +12,9 @@ variable "aws_account_id" {
   description = "The AWS account ID for the Storage Lens configuration."
   type        = string
 }
+
+variable "tags" {
+  description = "Tags applied to all resources created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/s3.tf
+++ b/s3.tf
@@ -39,6 +39,8 @@ resource "aws_iam_policy" "s3_access_policy" {
       }
     ]
   })
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "s3_access_policy_attachment" {


### PR DESCRIPTION
## Summary

Adds introspection capabilities to the cross account role as well as module version tags. The version bump is manually triggered and recommended by a PR template until proper release automation is set up.

## Checklist

- [x] Ensure you have bumped the `local.module_version` value in `main.tf` accordingly with semver conventions

## Release procedure

After this PR is merged, cut a release with:

```
gh release create v0.11.0 --generate-notes
```