### PR TITLE
fix: replace deprecated output value

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "account_id" {
 
 output "account_region" {
   description = "The AWS region of the account where the module was provisioned."
-  value       = data.aws_region.current.name
+  value       = data.aws_region.current.region
 }
 
 output "role_arn" {


### PR DESCRIPTION
## Summary

Fixes the deprecated property. Replaces `name` with `region`.

```shell
Warning: Deprecated value used
│ 
│   on .terraform/modules/infracost_management_account/outputs.tf line 8, in output "account_region":
│    8:   value       = data.aws_region.current.name
│ 
│   The deprecation originates from module.infracost_management_account.data.aws_region.current.name
│ 
│ name is deprecated. Use region instead.
│ 
```

