### PR TITLE
docs: update infracost_external_id description (TRK-294)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "infracost_external_id" {
-  description = "Your Infracost Organization ID (get it from Org Settings under Settings in the https://dashboard.infracost.io)"
+  description = "Your Infracost External ID, copied from the Infracost UI."
   type        = string
 }
 


### PR DESCRIPTION
## Summary

The `infracost_external_id` Terraform variable no longer accepts "your Infracost organization ID" — the value is now resolved server-side and shown in the Infracost UI for the customer to copy. Updates the variable description accordingly.

- [x] `/review` at commit [ea661bb](https://github.com/infracost/cross-account-link/commit/ea661bb086f160479bcb4eed02972a71794128ad) produced a risk score of 1/10. One-line description change in `variables.tf` aligning with [TRK-294](https://linear.app/infracost/issue/TRK-294).
