### PR TITLE
fix(s3): harden export bucket security and add optional KMS encryption

### DIFF
--- a/exports.tf
+++ b/exports.tf
@@ -16,6 +16,7 @@ module "billing_and_cost_management_export" {
   depends_on = [terraform_data.validate_is_management]
 
   aws_account_id = data.aws_caller_identity.current.account_id
+  kms_key_arn    = var.kms_key_arn
   tags           = local.common_tags
 }
 
@@ -28,5 +29,6 @@ module "s3_storage_lens_export" {
   aws_account_id         = data.aws_caller_identity.current.account_id
   aws_organization_arn   = data.aws_organizations_organization.current.arn
   aws_trusted_principals = data.aws_organizations_organization.current.aws_service_access_principals
+  kms_key_arn            = var.kms_key_arn
   tags                   = local.common_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -234,3 +234,33 @@ resource "aws_iam_role_policy_attachment" "role_introspection_policy_attachment"
   policy_arn = aws_iam_policy.role_introspection_policy.arn
   role       = aws_iam_role.cross_account_role.name
 }
+
+resource "aws_iam_policy" "kms_decrypt_policy" {
+  count       = var.is_management_account && var.kms_key_arn != null ? 1 : 0
+  name        = "infracost-kms-decrypt${var.role_suffix}"
+  path        = "/"
+  description = "Allows the Infracost cross-account role to decrypt S3 export objects using the customer-managed KMS key"
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Sid : "InfracostKMSDecrypt",
+        Effect : "Allow",
+        Action : [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+        ],
+        Resource : var.kms_key_arn,
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "kms_decrypt_policy_attachment" {
+  count      = var.is_management_account && var.kms_key_arn != null ? 1 : 0
+  policy_arn = aws_iam_policy.kms_decrypt_policy[0].arn
+  role       = aws_iam_role.cross_account_role.name
+}

--- a/modules/billing-and-cost-management/bucket.tf
+++ b/modules/billing-and-cost-management/bucket.tf
@@ -18,6 +18,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {
     expiration {
       days = 365
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
@@ -50,6 +54,29 @@ data "aws_iam_policy_document" "data_exports_policy_doc" {
       values = [
         var.aws_account_id,
       ]
+    }
+  }
+
+  statement {
+    sid    = "DenyNonSSLRequests"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.bcm_data_exports.arn,
+      "${aws_s3_bucket.bcm_data_exports.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
     }
   }
 }

--- a/modules/billing-and-cost-management/bucket.tf
+++ b/modules/billing-and-cost-management/bucket.tf
@@ -3,6 +3,27 @@ resource "aws_s3_bucket" "bcm_data_exports" {
   tags   = var.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "bcm_data_exports" {
+  bucket                  = aws_s3_bucket.bcm_data_exports.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bcm_data_exports" {
+  count  = var.kms_key_arn != null ? 1 : 0
+  bucket = aws_s3_bucket.bcm_data_exports.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {
   bucket = aws_s3_bucket.bcm_data_exports.id
 

--- a/modules/billing-and-cost-management/variables.tf
+++ b/modules/billing-and-cost-management/variables.tf
@@ -8,3 +8,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "kms_key_arn" {
+  description = "ARN of a KMS key to use for server-side encryption of the S3 bucket. If null, SSE-S3 (AES-256) is used."
+  type        = string
+  default     = null
+}

--- a/modules/s3-storage-lens/bucket.tf
+++ b/modules/s3-storage-lens/bucket.tf
@@ -3,6 +3,27 @@ resource "aws_s3_bucket" "storage_lens_data_exports" {
   tags   = var.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "storage_lens_data_exports" {
+  bucket                  = aws_s3_bucket.storage_lens_data_exports.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "storage_lens_data_exports" {
+  count  = var.kms_key_arn != null ? 1 : 0
+  bucket = aws_s3_bucket.storage_lens_data_exports.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {
   bucket = aws_s3_bucket.storage_lens_data_exports.id
 

--- a/modules/s3-storage-lens/bucket.tf
+++ b/modules/s3-storage-lens/bucket.tf
@@ -18,6 +18,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "data_exports_lifecycle" {
     expiration {
       days = 365
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
@@ -49,6 +53,29 @@ data "aws_iam_policy_document" "data_exports_policy_doc" {
       values = [
         var.aws_account_id,
       ]
+    }
+  }
+
+  statement {
+    sid    = "DenyNonSSLRequests"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.storage_lens_data_exports.arn,
+      "${aws_s3_bucket.storage_lens_data_exports.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
     }
   }
 }

--- a/modules/s3-storage-lens/variables.tf
+++ b/modules/s3-storage-lens/variables.tf
@@ -18,3 +18,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "kms_key_arn" {
+  description = "ARN of a KMS key to use for server-side encryption of the S3 bucket. If null, SSE-S3 (AES-256) is used."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,9 @@ variable "enable_data_exports" {
   type        = bool
   default     = false
 }
+
+variable "kms_key_arn" {
+  description = "ARN of a KMS key to use for server-side encryption of the data export S3 buckets. If null, SSE-S3 (AES-256) is used."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

Hardens both S3 export buckets (BCM data exports and S3 Storage Lens exports) and adds optional KMS encryption support:

- **[S3.5] SSL-only access**: Added a `DenyNonSSLRequests` statement to each bucket policy to block non-HTTPS requests.
- **Incomplete multipart upload cleanup**: Added `abort_incomplete_multipart_upload` (7 days) to the existing lifecycle rules to avoid accumulating costs from failed uploads.
- **Public access block**: Enabled all four public access block settings on both buckets.
- **Optional KMS encryption**: New `kms_key_arn` variable (default `null`) on the root module and both submodules. When set, configures SSE-KMS with bucket key enabled; falls back to SSE-S3 otherwise.
- **IAM policy for KMS**: When `kms_key_arn` is set, a scoped IAM policy granting `kms:Decrypt` and `kms:DescribeKey` on that key is created and attached to the cross-account role.

> **Note:** When using a customer-managed KMS key, users must also update their KMS key policy to grant `kms:GenerateDataKey` and `kms:Decrypt` to the AWS service principals (`bcm-data-exports.amazonaws.com`, `billingreports.amazonaws.com`, `storage-lens.s3.amazonaws.com`) that write to the export buckets. A concrete key policy example is included in the documentation.

Documentation for the `kms_key_arn` variable, including the required KMS key policy, has been added in [infracost/docs#913](https://github.com/infracost/docs/pull/913).